### PR TITLE
annotate: fix index

### DIFF
--- a/src/pkg/commands/commands.go
+++ b/src/pkg/commands/commands.go
@@ -91,7 +91,7 @@ func (c Commands) Run() error {
 	}
 
 	// must be trying to run a command
-	if cmd := c.Find(flag.Arg(1)); cmd != nil {
+	if cmd := c.Find(flag.Arg(0)); cmd != nil {
 		if f := cmd.FlagSet(); f != nil {
 			f.Parse(flag.Args()[1:])
 		}


### PR DESCRIPTION
Used the wrong flag index so commands would not run.